### PR TITLE
[feat] MemoryInput & validator

### DIFF
--- a/src/components/inputs/MemoryInput.test.tsx
+++ b/src/components/inputs/MemoryInput.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, act } from "@testing-library/react";
+import { CPUSelect } from "./CPUSelect";
+import { CPUModel } from "../../types/types";
+import { selectClickTarget, setup } from "../../utils/test";
+import { MemoryInput } from "./MemoryInput";
+
+describe("MemoryInput Component Tests", () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  test("renders with correct initial state", () => {
+    render(<MemoryInput value="" onChange={mockOnChange} />);
+
+    // check rendered
+    const inputElement = screen.getByTestId("memory-input");
+    expect(inputElement).toBeInTheDocument();
+
+    // check helper text
+    expect(
+      screen.getByText(/Memory must be a power of 2/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Examples:/i)).toBeInTheDocument();
+  });
+
+  test("should format initial value with commas", () => {
+    render(<MemoryInput value="4096" onChange={mockOnChange} />);
+
+    // Input should show formatted value
+    const inputElement = screen.getByTestId("memory-input");
+    expect(inputElement).toHaveValue("4,096");
+  });
+
+  test("should handle valid input correctly", async () => {
+    const { user } = setup(<MemoryInput value="" onChange={mockOnChange} />);
+
+    // Enter a valid memory size
+    const inputElement = screen.getByTestId("memory-input");
+    await user.type(inputElement, "8192");
+
+    // Should call onChange with valid=true
+    expect(mockOnChange).toHaveBeenCalledWith("8192", true, 8192);
+
+    // No error message should be displayed
+    expect(screen.queryByText(/multiple of 1024MB/i)).not.toHaveClass(
+      "Mui-error"
+    );
+  });
+
+  test("should reject input that is not a power of 2", async () => {
+    const { user } = setup(<MemoryInput value="" onChange={mockOnChange} />);
+
+    // Enter a valid memory size
+    const inputElement = screen.getByTestId("memory-input");
+    await user.type(inputElement, "3072");
+
+    // Should call onChange with valid=false
+    const lastCall =
+      mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1];
+    expect(lastCall[0]).toBe("3072");
+    expect(lastCall[1]).toBe(false);
+
+    // Error message should be displayed
+    expect(screen.getByText(/power of 2/i)).toBeInTheDocument();
+  });
+
+  test("should reject input below minimum size", async () => {
+    const { user } = setup(<MemoryInput value="" onChange={mockOnChange} />);
+
+    // Enter a memory size below the minimum
+    const inputElement = screen.getByTestId("memory-input");
+    await user.type(inputElement, "1024");
+
+    const lastCall =
+      mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1];
+    expect(lastCall[0]).toBe("1024");
+    expect(lastCall[1]).toBe(false);
+
+    // Error message should be displayed
+    expect(screen.getByText(/at least 2,048MB/i)).toBeInTheDocument();
+  });
+
+  test("should reject input that is not a multiple of 1024", async () => {
+    const { user } = setup(<MemoryInput value="" onChange={mockOnChange} />);
+
+    // Enter a memory size below the minimum
+    const inputElement = screen.getByTestId("memory-input");
+
+    // Enter a memory size that's not a multiple of 1024
+    await user.type(inputElement, "5000");
+
+    // Should call onChange with valid=false
+    const lastCall =
+      mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1];
+    expect(lastCall[0]).toBe("5000");
+    expect(lastCall[1]).toBe(false);
+
+    // Error message should be displayed
+    expect(screen.getByText(/multiple of 1024MB/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/inputs/MemoryInput.tsx
+++ b/src/components/inputs/MemoryInput.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from "react";
+import { TextField, Typography } from "@mui/material";
+import { validateMemoryInput, formatWithCommas } from "../../utils/validators";
+
+interface MemoryInputProps {
+  value: string;
+  onChange: (value: string, isValid: boolean, numericValue?: number) => void;
+}
+
+export const MemoryInput: React.FC<MemoryInputProps> = ({
+  value,
+  onChange,
+}) => {
+  const [error, setError] = useState<string>("");
+  const [internalValue, setInternalValue] = useState<string>(value);
+
+  // Format initial value with commas if it's a valid number
+  useEffect(() => {
+    if (value && !isNaN(Number(value.replace(/,/g, "")))) {
+      const numValue = parseInt(value.replace(/,/g, ""), 10);
+      setInternalValue(formatWithCommas(numValue));
+    }
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value;
+    setInternalValue(input);
+
+    // If input is empty, clear error but mark as invalid
+    if (!input.trim()) {
+      setError("");
+      onChange(input, false);
+      return;
+    }
+
+    const validation = validateMemoryInput(input);
+    setError(validation.errorMessage);
+    onChange(input, validation.isValid, validation.value);
+  };
+
+  const handleBlur = () => {
+    // Format the input with commas when the field is blurred (if valid)
+    if (internalValue && !error) {
+      const numValue = parseInt(internalValue.replace(/,/g, ""), 10);
+      setInternalValue(formatWithCommas(numValue));
+    }
+  };
+
+  return (
+    <>
+      <TextField
+        label="Memory Size (MB)"
+        variant="outlined"
+        fullWidth
+        margin="normal"
+        value={internalValue}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        error={!!error}
+        helperText={
+          error ||
+          "Memory must be a power of 2, multiple of 1024MB, between 2,048MB-8,388,608MB"
+        }
+        placeholder="Example: 4,096"
+        slotProps={{
+          htmlInput: {
+            "data-testid": "memory-input",
+          },
+        }}
+      />
+      <Typography
+        variant="body2"
+        color="textSecondary"
+        style={{ marginTop: -12, marginBottom: 16 }}
+      >
+        Examples: 2,048MB, 4,096MB, 8,192MB, 16,384MB, etc.
+      </Typography>
+    </>
+  );
+};

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -1,0 +1,83 @@
+import { validateMemorySize, validateMemoryInput, formatWithCommas } from '../utils/validators';
+
+describe('Format With Commas Tests', () => {
+  test('should format numbers with commas correctly', () => {
+    expect(formatWithCommas(1000)).toBe('1,000');
+    expect(formatWithCommas(1000000)).toBe('1,000,000');
+    expect(formatWithCommas(4096)).toBe('4,096');
+    expect(formatWithCommas(524288)).toBe('524,288');
+    expect(formatWithCommas(8388608)).toBe('8,388,608');
+  });
+  
+  test('should handle small numbers without commas', () => {
+    expect(formatWithCommas(100)).toBe('100');
+    expect(formatWithCommas(999)).toBe('999');
+  });
+}); 
+describe('Memory Size Tests', () => {
+    test('should invalidate memory size that is less than 2,048MB', () => {
+    const result = validateMemorySize(1024);
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("at least 2,048MB");
+  });
+  
+  test('should invalidate memory size that exceeds 8,388,608MB', () => {
+    const result = validateMemorySize(16777216); // 16 million
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("must not exceed");
+  });
+  
+  test('should invalidate memory size that is not a multiple of 1024', () => {
+    const result = validateMemorySize(3000);
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("multiple of 1024MB");
+  });
+  
+  test('should invalidate memory size that is not a power of 2', () => {
+    const result = validateMemorySize(3072); // 3 * 1024, not a power of 2
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("power of 2");
+  });
+  
+  test('should accept valid power of 2 values', () => {
+    // Test various valid powers of 2
+    const validSizes = [2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608];
+    
+    validSizes.forEach(size => {
+      const result = validateMemorySize(size);
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBe("");
+    });
+  });
+});
+
+describe('Memory Input Validation Tests', () => {
+  test('should validate properly formatted memory input', () => {
+    const result = validateMemoryInput('4,096');
+    expect(result.isValid).toBe(true);
+    expect(result.value).toBe(4096);
+  });
+  
+  test('should validate memory input without commas', () => {
+    const result = validateMemoryInput('4096');
+    expect(result.isValid).toBe(true);
+    expect(result.value).toBe(4096);
+  });
+    test('should invalidate memory input with invalid characters', () => {
+    const result = validateMemoryInput('4096x');
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("only digits and commas");
+  });
+  
+  test('should invalidate memory input that is not a power of 2', () => {
+    const result = validateMemoryInput('3,072');
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("power of 2");
+  });
+  
+  test('should invalidate memory input below the minimum', () => {
+    const result = validateMemoryInput('1,024');
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toContain("at least 2,048MB");
+  });
+});

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,49 @@
+export const validateMemorySize = (memorySize: number): { isValid: boolean; errorMessage: string } => {
+  if (isNaN(memorySize)) {
+    return { isValid: false, errorMessage: "Memory size must be a number" };
+  }
+
+  if (!Number.isInteger(memorySize)) {
+    return { isValid: false, errorMessage: "Memory size must be an integer" };
+  }
+
+  if (memorySize < 2048) {
+    return { isValid: false, errorMessage: "Memory size must be at least 2,048MB" };
+  }
+
+  if (memorySize > 8388608) {
+    return { isValid: false, errorMessage: "Memory size must not exceed 8,388,608MB" };
+  }
+
+  if (memorySize % 1024 !== 0) {
+    return { isValid: false, errorMessage: "Memory size must be a multiple of 1024MB" };
+  }
+
+  const log2 = Math.log2(memorySize);
+  if (!Number.isInteger(log2)) {
+    return { isValid: false, errorMessage: "Memory size must be a power of 2" };
+  }
+
+  return { isValid: true, errorMessage: "" };
+};
+
+export const validateMemoryInput = (input: string): { isValid: boolean; errorMessage: string; value?: number } => {
+  const cleanedInput = input.replace(/,/g, "");
+  
+  if (!/^\d+$/.test(cleanedInput)) {
+    return { isValid: false, errorMessage: "Memory size must contain only digits and commas" };
+  }
+  
+  const numericValue = parseInt(cleanedInput, 10);
+  const memoryValidation = validateMemorySize(numericValue);
+  
+  return {
+    isValid: memoryValidation.isValid,
+    errorMessage: memoryValidation.errorMessage,
+    value: memoryValidation.isValid ? numericValue : undefined
+  };
+};
+
+export const formatWithCommas = (value: number): string => {
+  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};


### PR DESCRIPTION
Memory Size: Memory must be a multiple of 1024 in MB, also must be a power of 2 (Example: 2,048MB, 4,096MB is acceptable. But 3,072MB is not acceptable). And not less than 2,048MB, this attribute is a Textarea that can be input by user. The range of this attribute is 4,096MB (included)-8,388,608MB (included). Comma separated integer number is the only format this attribute can take.